### PR TITLE
update link for MNIST digits download instructions

### DIFF
--- a/7_clustering/clustering.ipynb
+++ b/7_clustering/clustering.ipynb
@@ -346,7 +346,7 @@
     "editable": true
    },
    "source": [
-    "**(Бонусные 2 балла)** Скачайте датасет [MNIST Handwritten Digits](http://yann.lecun.com/exdb/mnist). Как сделать это с помощью scikit-learn, написано [здесь](http://scikit-learn.org/stable/datasets/index.html#downloading-datasets-from-the-mldata-org-repository). MNIST Handwritten Digits – это 70 тысяч распознанных рукописных изображений цифр, каждое размером 28 $\\times$ 28 пикселей. Попробуйте прокластеризовать этот датасет и добиться как можно лучших значений силуэта и $V$-меры."
+    "**(Бонусные 2 балла)** Скачайте датасет [MNIST Handwritten Digits](http://yann.lecun.com/exdb/mnist). Как сделать это с помощью scikit-learn, написано [здесь](https://stackoverflow.com/a/60450028). MNIST Handwritten Digits – это 70 тысяч распознанных рукописных изображений цифр, каждое размером 28 $\\times$ 28 пикселей. Попробуйте прокластеризовать этот датасет и добиться как можно лучших значений силуэта и $V$-меры."
    ]
   },
   {


### PR DESCRIPTION
In sklearn 0.20+ fetch_mldata() is deprecated. Instead fetch_openml() is used. Link leads to stackoverflow answer on this topic.