### PR TITLE
fix typo in module 6

### DIFF
--- a/6_feature_engineering_selection/homework.ipynb
+++ b/6_feature_engineering_selection/homework.ipynb
@@ -318,7 +318,7 @@
     "2) run algorithm (with k=2) on scaled data    \n",
     "3) plot results: highlight different clusters using different colors.\n",
     "\n",
-    "You can use this [question](https://stats.stackexchange.com/questions/89809/is-it-important-to-scale-data-before-clustering/89813) as a hint, but I recommend you to plot results using `plot_scatter` with `equal_scaled=True`: it might help you to intuitively understand the reasons of such scaling impact.\n"
+    "You can use this [question](https://stats.stackexchange.com/questions/89809/is-it-important-to-scale-data-before-clustering/89813) as a hint, but I recommend you to plot results using `plot_scatter` with `auto_scaled=False`: it might help you to intuitively understand the reasons of such scaling impact.\n"
    ]
   },
   {


### PR DESCRIPTION
There's no **equal_scaled** parameter in **plot_scatter** function. I suppose by **equal_scaled=True** author meant equal scale for both axes. This can be configured by turning off auto scaling, i.e. via **auto_scaled=False**.